### PR TITLE
fix browserify for third-party projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "es3ify": "0.1.3",
     "promise-nodify": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
If you try use this package in third-party project and build them with browserify you get error like this:

```
Error: Cannot find module 'es3ify' from '/home/kirill/blockchainjs/node_modules/pouchdb-erase'
```

because you have es3ify transformation in browserify field in package.json, I added es3ify to dependencies and build was successful.
